### PR TITLE
Set right permissions and creating an keypair in the refreshed create page

### DIFF
--- a/packages/common/actions/workflow.js
+++ b/packages/common/actions/workflow.js
@@ -1,6 +1,7 @@
 export const INIT_WORKFLOW = '@workflow/INIT_WORKFLOW';
 export const INIT_TEAMS = '@workflow/INIT_TEAMS';
 export const INIT_SETTINGS = '@workflow/INIT_SETTINGS';
+export const INIT_CREATE_PAGE = '@workflow/INIT_CREATE_PAGE';
 export const INIT_DASHBOARD = '@workflow/INIT_DASHBOARD';
 export const FINISH_PROCESSING_KEYPAIRS =
   '@workflow/FINISH_PROCESSING_KEYPAIRS';
@@ -35,6 +36,10 @@ export const initWorkflow = (withDecryption = true) => ({
   payload: {
     withDecryption,
   },
+});
+
+export const initCreatePage = () => ({
+  type: INIT_CREATE_PAGE,
 });
 
 export const initTeams = () => ({

--- a/packages/common/reducers/workflow.js
+++ b/packages/common/reducers/workflow.js
@@ -11,6 +11,7 @@ import {
   OPEN_CURRENT_VAULT,
   INIT_DASHBOARD,
   FINISH_PROCESSING_KEYPAIRS,
+  INIT_CREATE_PAGE,
 } from '@caesar/common/actions/workflow';
 
 const initialState = {
@@ -39,6 +40,9 @@ export default createReducer(initialState, {
     return state;
   },
   [INIT_DASHBOARD](state) {
+    return state;
+  },
+  [INIT_CREATE_PAGE](state) {
     return state;
   },
   [FINISH_PROCESSING_KEYPAIRS](state) {

--- a/packages/common/sagas/entities/item.js
+++ b/packages/common/sagas/entities/item.js
@@ -78,7 +78,6 @@ import {
 } from '@caesar/common/utils/cipherUtils';
 import { getServerErrorMessage } from '@caesar/common/utils/error';
 import { chunk } from '@caesar/common/utils/utils';
-import { createPermissionsFromLinks } from '@caesar/common/utils/createPermissionsFromLinks';
 import {
   ENTITY_TYPE,
   COMMON_PROGRESS_NOTIFICATION,
@@ -101,6 +100,7 @@ import { passwordGenerator } from '@caesar/common/utils/passwordGenerator';
 import { generateKeys } from '@caesar/common/utils/key';
 import { addSystemItemsBatch } from '@caesar/common/actions/entities/system';
 import { memberSelector } from '../../selectors/entities/member';
+import { convertItemsToEntities } from '../../normalizers/normalizers';
 
 const ITEMS_CHUNK_SIZE = 50;
 
@@ -426,12 +426,12 @@ export function* saveItemSaga({ item, publicKey }) {
   const itemData = {
     ...item,
     ...serverItemData,
-    teamId: item.teamId || TEAM_TYPE.PERSONAL,
-    _permissions: createPermissionsFromLinks(serverItemData._links) || {},
     secret,
   };
+  const { itemsById } = convertItemsToEntities([itemData]);
+  const normalizedItem = Object.values(itemsById).shift();
 
-  return itemData;
+  return normalizedItem;
 }
 
 export function* getKeyPairForTeam(teamId) {
@@ -584,17 +584,9 @@ export function* createItemSaga({
       yield put(updateGlobalNotification(CREATING_ITEM_NOTIFICATION, true));
     }
 
-    const itemFromServer = yield call(saveItemSaga, { item, publicKey });
-
-    // TODO: Make the class of the item instead of the direct object
-    const newItem = {
-      ...item,
-      ...itemFromServer,
-      _permissions: createPermissionsFromLinks(itemFromServer._links),
-    };
-
+    const savedItem = yield call(saveItemSaga, { item, publicKey });
     if (!isSystemItem) {
-      yield put(createItemSuccess(newItem));
+      yield put(createItemSuccess(savedItem));
     }
 
     const currentTeamId = yield select(currentTeamIdSelector);
@@ -604,7 +596,7 @@ export function* createItemSaga({
         (!teamId && currentTeamId === TEAM_TYPE.PERSONAL)) &&
       !isSystemItem
     ) {
-      yield put(addItemToList(newItem));
+      yield put(addItemToList(savedItem));
     }
 
     yield put(setCurrentTeamId(teamId || TEAM_TYPE.PERSONAL));
@@ -612,17 +604,17 @@ export function* createItemSaga({
     if (isSystemItem) {
       yield put(
         addSystemItemsBatch({
-          [newItem.id]: newItem,
+          [savedItem.id]: savedItem,
         }),
       );
       if (data.name.includes(ENTITY_TYPE.TEAM)) {
-        yield put(addTeamKeyPair(newItem));
+        yield put(addTeamKeyPair(savedItem));
       } else {
-        yield put(addShareKeyPair(newItem));
+        yield put(addShareKeyPair(savedItem));
       }
     } else {
       yield put(setWorkInProgressListId(listId));
-      yield put(setWorkInProgressItem(newItem));
+      yield put(setWorkInProgressItem(savedItem));
       yield call(Router.push, ROUTES.DASHBOARD);
     }
   } catch (error) {

--- a/packages/common/sagas/entities/team.js
+++ b/packages/common/sagas/entities/team.js
@@ -155,9 +155,7 @@ export function* createTeamKeyPairSaga({ payload: { team, publicKey } }) {
     }
 
     const teamKeyPair = yield call(generateTeamKeyPair, {
-      payload: {
-        name: team.title,
-      },
+      name: team.title,
     });
 
     const { id: listId } = yield select(teamDefaultListSelector, {
@@ -321,9 +319,7 @@ export function* createTeamSaga({
     };
 
     const teamKeyPair = yield call(generateTeamKeyPair, {
-      payload: {
-        name: title,
-      },
+      name: title,
     });
 
     if (!teamKeyPair) {

--- a/packages/common/utils/item.js
+++ b/packages/common/utils/item.js
@@ -81,7 +81,7 @@ export const convertSystemItemToKeyPair = item => {
 
   return {
     id: item.id,
-    password: password,
+    password,
     publicKey,
     privateKey,
   };
@@ -92,11 +92,10 @@ export const decryptItemData = async (item, privateKeyObject) => {
     const { data: encryptedData, raws: encryptedRaws } = JSON.parse(
       item.secret,
     );
-
     const promises = [];
     promises.push(decryptItem(encryptedData, privateKeyObject));
 
-    if (!isGeneralItem(item)) {
+    if (!isGeneralItem(item) && encryptedRaws) {
       promises.push(decryptItem(encryptedRaws, privateKeyObject));
     }
 

--- a/packages/components/AddItem/AddItem.js
+++ b/packages/components/AddItem/AddItem.js
@@ -74,7 +74,7 @@ export const AddItem = ({ className }) => {
   const itemPermission = {
     ..._permissions,
     __typename:
-      currentTeam.id === TEAM_TYPE.PERSONAL
+      (currentTeam?.id || TEAM_TYPE.PERSONAL) === TEAM_TYPE.PERSONAL
         ? PERMISSION_ENTITY.ITEM
         : PERMISSION_ENTITY.TEAM_ITEM,
   };

--- a/packages/components/CreateForm/CreateForm.js
+++ b/packages/components/CreateForm/CreateForm.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import { useRouter } from 'next/router';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { useFormik } from 'formik';
 import styled from 'styled-components';
 import { createItemRequest } from '@caesar/common/actions/entities/item';
 import { processUploadedFiles } from '@caesar/common/utils/attachment';
-import { userIdSelector } from '@caesar/common/selectors/user';
 import { FormByType, FormHeader, FormFooter } from './components';
 import { getInitialValues, getValidationSchema } from './utils';
 

--- a/packages/components/MenuList/components/MenuListInner.js
+++ b/packages/components/MenuList/components/MenuListInner.js
@@ -177,7 +177,7 @@ const MenuListInnerComponent = ({
   const listPermission = {
     ..._permissions,
     __typename:
-      currentTeam.id === TEAM_TYPE.PERSONAL
+      (currentTeam?.id || TEAM_TYPE.PERSONAL) === TEAM_TYPE.PERSONAL
         ? PERMISSION_ENTITY.LIST
         : PERMISSION_ENTITY.TEAM_LIST,
   };

--- a/packages/containers/Create/Create.js
+++ b/packages/containers/Create/Create.js
@@ -1,14 +1,18 @@
 import React from 'react';
 import { useEffectOnce } from 'react-use';
-import { useDispatch } from 'react-redux';
-import { initWorkflow } from '@caesar/common/actions/workflow';
+import { useDispatch, batch } from 'react-redux';
+import { initCreatePage } from '@caesar/common/actions/workflow';
 import { CreateLayout, CreateForm } from '@caesar/components';
+import { fetchUserSelfRequest } from '@caesar/common/actions/user';
 
 export const Create = () => {
   const dispatch = useDispatch();
 
   useEffectOnce(() => {
-    dispatch(initWorkflow());
+    batch(() => {
+      dispatch(fetchUserSelfRequest());
+      dispatch(initCreatePage());
+    });
   });
 
   return (


### PR DESCRIPTION
Set right permissions after an item is created, fix creating an keypair in the refreshed create page.

Signed-off-by: Aleksandr Beshkenadze <beshkenadze@gmail.com>